### PR TITLE
Fixes some stations and adds others

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,30 +1,18 @@
+### Maven
+
+/target
+
+### IntelliJ
+
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
-# User-specific stuff:
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/dictionaries
-.idea/vcs.xml
-.idea/jsLibraryMappings.xml
+## Directory-based project format
+.idea/
 
-# Sensitive or high-churn files:
-.idea/dataSources.ids
-.idea/dataSources.xml
-.idea/dataSources.local.xml
-.idea/sqlDataSources.xml
-.idea/dynamic.xml
-.idea/uiDesigner.xml
-
-# Gradle:
-.idea/gradle.xml
-.idea/libraries
-
-# Mongo Explorer plugin:
-.idea/mongoSettings.xml
-
-## File-based project format:
+## File-based project format
 *.iws
+*.iml
 
 ## Plugin-specific files:
 

--- a/src/main/java/me/cassayre/florian/netherrail/Station.java
+++ b/src/main/java/me/cassayre/florian/netherrail/Station.java
@@ -169,8 +169,9 @@ public enum Station
     UNKNOWN_15(-414, -1740, "Inconnue", StationType.INTERSECTION_ONLY, true, false),
     TENTACLES_PORT(158, -1436, "Port de Tentaclès", StationType.INTERSECTION_AND_PORTAL),
     NOT_FINISHED_4(30, -1682, "Station inconnue", StationType.INTERSECTION_AND_PORTAL), // Portail ne menant nulle part
-    KAAMELOTT(-234, -1454, "Kaamelott", StationType.PORTAL_ONLY),
-    POMMACROBATICS(-234, -1604, "PommAcrobatics", StationType.PORTAL_ONLY),
+    KAAMELOTT(-234, -1454, "Kaamelott"),
+    POMMACROBATICS(-234, -1604, "PommAcrobatics"),
+    CHEZ_NAGAIWA(-234, -1706, "Chez Nagaiwa")
 
 
 
@@ -208,7 +209,8 @@ public enum Station
         register(GORGES_GROTTES, GHAST, null, ENGORIA, null); //
         register(BOREE, KAAMELOTT, SEPTENTRION, LAC_AMOUREUX, GARDIENS); //
         register(KAAMELOTT, POMMACROBATICS, null, BOREE, null); //
-        register(POMMACROBATICS, KAAMELOTT, null, UNKNOWN_14, null); //
+        register(POMMACROBATICS, KAAMELOTT, null, CHEZ_NAGAIWA, null); //
+        register(CHEZ_NAGAIWA, POMMACROBATICS, null, UNKNOWN_14, null); //
         register(KERSUB, UNKNOWN_15, null, null, null); //
         register(GHAST, UNKNOWN_12, PIC_ASSAUT, GORGES_GROTTES, MOREA);
         register(MOREA, null, GHAST, null, CARBONE); //
@@ -332,7 +334,7 @@ public enum Station
         register(HASHTAG, null, FORTERESSE_MYSTERIEUSE, null, ILE_ZACQUES);
         register(ILE_ZACQUES, null, HASHTAG, null, DEPOT);
         register(UNKNOWN_13, null, COLLINE_BOULEAUX, FJORDS, null);
-        register(UNKNOWN_14, null, null, POMMACROBATICS, UNKNOWN_15);
+        register(UNKNOWN_14, null, null, CHEZ_NAGAIWA, UNKNOWN_15);
         register(UNKNOWN_15, null, UNKNOWN_14, KERSUB, null);
         register(NOT_FINISHED_4, null, null, SEPTENTRION, null);
 

--- a/src/main/java/me/cassayre/florian/netherrail/Station.java
+++ b/src/main/java/me/cassayre/florian/netherrail/Station.java
@@ -51,10 +51,8 @@ public enum Station
     WITHER(-234, -1232, "Lande du Wither", StationType.INTERSECTION_AND_PORTAL),
     CREVASSES(-234, -1315, "Croisée des crevasses"),
     LAC_AMOUREUX(-234, -1351, "Lac des amoureux"),
-    NOT_FINISHED_4(30, -1682, "Station inconnue", StationType.INTERSECTION_AND_PORTAL), // Portail ne menant nulle part
     SEPTENTRION(30, -1436, "Septentrion", StationType.INTERSECTION_AND_PORTAL),
     TENTACLES(206, -1436, "Tentaclès", StationType.INTERSECTION_AND_PORTAL),
-    TENTACLES_PORT(158, -1436, "Port de Tentaclès", StationType.INTERSECTION_AND_PORTAL),
     MESAPLAYA(30, -1278, "Mesaplaya", StationType.INTERSECTION_AND_PORTAL),
     RIVE_BLANCHE(30, -1207, "Rive Blanche", StationType.INTERSECTION_AND_PORTAL),
     FALAISIE(30, -1069, "Falaisie", StationType.INTERSECTION_ONLY),
@@ -169,6 +167,8 @@ public enum Station
     UNKNOWN_13(-529, -853, "Inconnue", StationType.INTERSECTION_ONLY, true, false),
     UNKNOWN_14(-234, -1740, "Inconnue", StationType.INTERSECTION_ONLY, true, false),
     UNKNOWN_15(-414, -1740, "Inconnue", StationType.INTERSECTION_ONLY, true, false),
+    TENTACLES_PORT(158, -1436, "Port de Tentaclès", StationType.INTERSECTION_AND_PORTAL),
+    NOT_FINISHED_4(30, -1682, "Station inconnue", StationType.INTERSECTION_AND_PORTAL), // Portail ne menant nulle part
     KAAMELOTT(-234, -1454, "Kaamelott", StationType.PORTAL_ONLY),
     POMMACROBATICS(-234, -1604, "PommAcrobatics", StationType.PORTAL_ONLY),
 
@@ -334,6 +334,7 @@ public enum Station
         register(UNKNOWN_13, null, COLLINE_BOULEAUX, FJORDS, null);
         register(UNKNOWN_14, null, null, POMMACROBATICS, UNKNOWN_15);
         register(UNKNOWN_15, null, UNKNOWN_14, KERSUB, null);
+        register(NOT_FINISHED_4, null, null, SEPTENTRION, null);
 
 
         // check();

--- a/src/main/java/me/cassayre/florian/netherrail/Station.java
+++ b/src/main/java/me/cassayre/florian/netherrail/Station.java
@@ -53,6 +53,7 @@ public enum Station
     LAC_AMOUREUX(-234, -1351, "Lac des amoureux"),
     SEPTENTRION(30, -1436, "Septentrion", StationType.INTERSECTION_AND_PORTAL),
     TENTACLES(206, -1436, "Tentaclès", StationType.INTERSECTION_AND_PORTAL),
+    TENTACLES_PORT(158, -1436, "Port de Tentaclès", StationType.INTERSECTION_AND_PORTAL),
     MESAPLAYA(30, -1278, "Mesaplaya", StationType.INTERSECTION_AND_PORTAL),
     RIVE_BLANCHE(30, -1207, "Rive Blanche", StationType.INTERSECTION_AND_PORTAL),
     FALAISIE(30, -1069, "Falaisie", StationType.INTERSECTION_ONLY),
@@ -213,8 +214,9 @@ public enum Station
         register(WITHER, CREVASSES, null, PICS_PRECIPICES, null); //
         register(CREVASSES, LAC_AMOUREUX, null, WITHER, null); //
         register(LAC_AMOUREUX, BOREE, null, CREVASSES, null); //
-        register(SEPTENTRION, null, TENTACLES, MESAPLAYA, BOREE); //
-        register(TENTACLES, null, NORDET, null, SEPTENTRION); //
+        register(SEPTENTRION, null, TENTACLES_PORT, MESAPLAYA, BOREE); //
+        register(TENTACLES_PORT, null, TENTACLES, null, SEPTENTRION); //
+        register(TENTACLES, null, NORDET, null, TENTACLES_PORT); //
         register(MESAPLAYA, SEPTENTRION, null, RIVE_BLANCHE, null); //
         register(RIVE_BLANCHE, MESAPLAYA, null, FALAISIE, null); //
         register(FALAISIE, RIVE_BLANCHE, TUX, POINT_CENTRAL, PIC_ASSAUT);

--- a/src/main/java/me/cassayre/florian/netherrail/Station.java
+++ b/src/main/java/me/cassayre/florian/netherrail/Station.java
@@ -51,6 +51,7 @@ public enum Station
     WITHER(-234, -1232, "Lande du Wither", StationType.INTERSECTION_AND_PORTAL),
     CREVASSES(-234, -1315, "Croisée des crevasses"),
     LAC_AMOUREUX(-234, -1351, "Lac des amoureux"),
+    NOT_FINISHED_4(30, -1682, "Station inconnue", StationType.INTERSECTION_AND_PORTAL), // Portail ne menant nulle part
     SEPTENTRION(30, -1436, "Septentrion", StationType.INTERSECTION_AND_PORTAL),
     TENTACLES(206, -1436, "Tentaclès", StationType.INTERSECTION_AND_PORTAL),
     TENTACLES_PORT(158, -1436, "Port de Tentaclès", StationType.INTERSECTION_AND_PORTAL),
@@ -214,7 +215,7 @@ public enum Station
         register(WITHER, CREVASSES, null, PICS_PRECIPICES, null); //
         register(CREVASSES, LAC_AMOUREUX, null, WITHER, null); //
         register(LAC_AMOUREUX, BOREE, null, CREVASSES, null); //
-        register(SEPTENTRION, null, TENTACLES_PORT, MESAPLAYA, BOREE); //
+        register(SEPTENTRION, NOT_FINISHED_4, TENTACLES_PORT, MESAPLAYA, BOREE); //
         register(TENTACLES_PORT, null, TENTACLES, null, SEPTENTRION); //
         register(TENTACLES, null, NORDET, null, TENTACLES_PORT); //
         register(MESAPLAYA, SEPTENTRION, null, RIVE_BLANCHE, null); //

--- a/src/main/java/me/cassayre/florian/netherrail/Station.java
+++ b/src/main/java/me/cassayre/florian/netherrail/Station.java
@@ -169,8 +169,8 @@ public enum Station
     UNKNOWN_13(-529, -853, "Inconnue", StationType.INTERSECTION_ONLY, true, false),
     UNKNOWN_14(-234, -1740, "Inconnue", StationType.INTERSECTION_ONLY, true, false),
     UNKNOWN_15(-414, -1740, "Inconnue", StationType.INTERSECTION_ONLY, true, false),
-
-
+    KAAMELOTT(-234, -1454, "Kaamelott", StationType.PORTAL_ONLY),
+    POMMACROBATICS(-234, -1604, "PommAcrobatics", StationType.PORTAL_ONLY),
 
 
 
@@ -206,7 +206,9 @@ public enum Station
         register(ATLANTIS, ENGORIA, null, SORCIERES, null); //
         register(ENGORIA, GORGES_GROTTES, null, ATLANTIS, null); //
         register(GORGES_GROTTES, GHAST, null, ENGORIA, null); //
-        register(BOREE, UNKNOWN_14, SEPTENTRION, LAC_AMOUREUX, GARDIENS); //
+        register(BOREE, KAAMELOTT, SEPTENTRION, LAC_AMOUREUX, GARDIENS); //
+        register(KAAMELOTT, POMMACROBATICS, null, BOREE, null); //
+        register(POMMACROBATICS, KAAMELOTT, null, UNKNOWN_14, null); //
         register(KERSUB, UNKNOWN_15, null, null, null); //
         register(GHAST, UNKNOWN_12, PIC_ASSAUT, GORGES_GROTTES, MOREA);
         register(MOREA, null, GHAST, null, CARBONE); //
@@ -330,7 +332,7 @@ public enum Station
         register(HASHTAG, null, FORTERESSE_MYSTERIEUSE, null, ILE_ZACQUES);
         register(ILE_ZACQUES, null, HASHTAG, null, DEPOT);
         register(UNKNOWN_13, null, COLLINE_BOULEAUX, FJORDS, null);
-        register(UNKNOWN_14, null, null, BOREE, UNKNOWN_15);
+        register(UNKNOWN_14, null, null, POMMACROBATICS, UNKNOWN_15);
         register(UNKNOWN_15, null, UNKNOWN_14, KERSUB, null);
 
 

--- a/src/main/java/me/cassayre/florian/netherrail/Station.java
+++ b/src/main/java/me/cassayre/florian/netherrail/Station.java
@@ -95,7 +95,7 @@ public enum Station
     PICS_PRECIPICES(-234, -1183, "Pics et précipices"),
     TECI_TARZAN(294, -637, "La téci d'Tarzan"),
     CARTOUME(294, -604, "Cartoume", StationType.INTERSECTION_AND_PORTAL),
-    VENICE(294, -529, "Venice"),
+    VENICE(294, -529, "Venice", StationType.INTERSECTION_AND_PORTAL),
     PROJETZ(30, -613, "ProjetZ", StationType.INTERSECTION_AND_PORTAL),
     UNKNOWN_2(30, -408, "Inconnue", StationType.INTERSECTION_ONLY, true, false),
     VILLAGE_MAYA(30, -318, "Village Maya", StationType.INTERSECTION_AND_PORTAL),
@@ -157,7 +157,7 @@ public enum Station
     UNKNOWN_12(-341, -1208, "Inconnue", StationType.INTERSECTION_ONLY, true, false),
     USINE_OR(-527, -1208, "Usine à or et à XP"),
     POSEIDOPOLIS_EST(540, 251, "Poséidopolis Est", StationType.INTERSECTION_ONLY),
-    NOT_FINISHED_4(540, 539, "En travaux", StationType.INTERSECTION_ONLY, false, true),
+    SUDET(540, 539, "Sudet", StationType.INTERSECTION_ONLY, false, false),
     CARDINALE_EST(708, 539, "Cardinale Est", StationType.INTERSECTION_AND_PORTAL),
     SURET(540, 600, "Suret", StationType.INTERSECTION_AND_PORTAL),
     USINE_GARDIENS(426, 539, "Usine à gardiens", StationType.INTERSECTION_AND_PORTAL),
@@ -318,11 +318,11 @@ public enum Station
         register(BLAZES_POINT, null, null, CIUDAD, null);
         register(UNKNOWN_12, null, null, GHAST, USINE_OR);
         register(USINE_OR, null, UNKNOWN_12, null, null);
-        register(POSEIDOPOLIS_EST, MELBURNE, null, NOT_FINISHED_4, null);
-        register(NOT_FINISHED_4, POSEIDOPOLIS_EST, CARDINALE_EST, SURET, USINE_GARDIENS);
-        register(CARDINALE_EST, null, null, null, NOT_FINISHED_4);
-        register(SURET, NOT_FINISHED_4, null, null, null);
-        register(USINE_GARDIENS, null, NOT_FINISHED_4, null, FORTERESSE_MYSTERIEUSE);
+        register(POSEIDOPOLIS_EST, MELBURNE, null, SUDET, null);
+        register(SUDET, POSEIDOPOLIS_EST, CARDINALE_EST, SURET, USINE_GARDIENS);
+        register(CARDINALE_EST, null, null, null, SUDET);
+        register(SURET, SUDET, null, null, null);
+        register(USINE_GARDIENS, null, SUDET, null, FORTERESSE_MYSTERIEUSE);
         register(FORTERESSE_MYSTERIEUSE, null, USINE_GARDIENS, null, HASHTAG);
         register(HASHTAG, null, FORTERESSE_MYSTERIEUSE, null, ILE_ZACQUES);
         register(ILE_ZACQUES, null, HASHTAG, null, DEPOT);


### PR DESCRIPTION
- Fixed `.gitignore`.
- Fixed _Venice_ (wrong station type) and _Sudet_ (wrong name, was _Not Finished 4_).
- Added _Tentaclès Port_, _Kaamelott_, _PommAcrobatics_, _Chez Nagaiwa_, and another portal (_Not Finished 4, New Edition_: an unnamed portal at _Septentrion_'s north).

Closes #1.

_sssssss_
